### PR TITLE
Update binding mutability according to comment.

### DIFF
--- a/borrowed/README.md
+++ b/borrowed/README.md
@@ -100,7 +100,7 @@ fn foo() {
     xr = &mut y;          // Ok
 
     let mut x = 5;
-    let mut y = 6;
+    let y = 6;
     let mut xr = &x;
     xr = &y;              // Ok - xr is mut, even though the referenced data is not
 }


### PR DESCRIPTION
To give an example that referenced data is not mutable.