### PR TITLE
Update status of libarena crate

### DIFF
--- a/graphs/README.md
+++ b/graphs/README.md
@@ -180,6 +180,11 @@ objects), arena allocation is very efficient. Usually, all the objects are
 allocated from a contiguous chunk of memory, that improves cache coherency when
 you are traversing the graph.
 
+> **Update**: libarena has been moved out of tree
+([Issue #63457](https://github.com/rust-lang/rust/issues/63457)).
+> Consider using [typed_arena](https://crates.io/crates/typed_arena) or 
+[generational-arena](https://crates.io/crates/generational-arena) instead.
+
 In Rust, arena allocation is supported by the [libarena](https://doc.rust-lang.org/arena/index.html)
 crate and is used throughout the compiler. There are two kinds of arenas - typed
 and untyped. The former is more efficient and easier to use, but can only


### PR DESCRIPTION
Libarena links and hence corresponding code is no longer valid, due to https://github.com/rust-lang/rust/issues/63457.
Hence, providing reference to the typed-arena crate that is the actual libarena one, or generational-arena, which typed-arena suggests.